### PR TITLE
fix: katex overflow on mobile

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -141,3 +141,8 @@ h1, h2, h3, h4, h5, h6 {
     content: "";
   }
 }
+
+// Fix katex math equation overflowing text width
+.katex-display {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
Some blogposts have excess scrolling because the Katex equations overflow the post width.

**Before:**

<img width="496" alt="Screen Shot 2023-02-27 at 6 35 40 AM" src="https://user-images.githubusercontent.com/4398624/221553786-815bfef1-c7e6-414d-8caa-3070bbfb1bad.png">

**After** (scrollable):

<img width="496" alt="Screen Shot 2023-02-27 at 6 36 05 AM" src="https://user-images.githubusercontent.com/4398624/221553866-dce580db-4bf1-4568-9c7b-359e0ff920d8.png">
