### PR TITLE
Add ETHGlobal Hackathon banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,6 +167,12 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
         additionalLanguages: ["solidity"]
+      },
+      announcementBar: {
+        id: "ETHGlobal",
+        content:
+          '<span>🍎</span><a href="https://collective.flashbots.net/t/ethglobal-ny-hackathon-sept-22-24/2413" target="_blank" rel="noreferrer">Participate in the Flashbots hackathon track at ETHGlobal NY, Sept 22 - 24</a><span>🍎</span>',
+        isCloseable: false,
       }
     })
 })

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -146,3 +146,44 @@ h1, h2, h3, h4, h5, h6 {
 .katex-display {
   overflow-x: scroll;
 }
+
+/* Top banner */
+div[role=banner] { 
+  min-height: 32px;
+
+  > div {
+    min-height: 32px;
+    padding: 0px;
+    border: 0px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    column-gap: 10px;
+    background-color: #f1be47;
+    color: #000000;
+    text-align: center;
+    font-size: 100%;
+
+    a {
+      font-family: "CMU-Serif";
+      font-size: 16px;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+@media (min-width: 341px) and (max-width: 640px) {
+  div[role=banner] > div a {
+    flex-basis: 280px;
+  }
+}
+
+@media (max-width: 340px) {
+  div[role=banner] > div a {
+    flex-basis: 150px;
+  }
+}


### PR DESCRIPTION
# What
This PR adds a banner to the top of the Documentation page to promote the ETHGlobal Hackathon in NYC, coming up this weekend. 

The banner should be identical to the ones going live on the Flashbots [Homepage](https://github.com/flashbots/flashbots-website/pull/56) and [Docs](https://github.com/flashbots/flashbots-docs/pull/440).

<p align="center">
  <img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/a22828a1-8cc0-4296-866d-a5d20bf2ab0b" alt="Screenshot of the new webpage with a banner"/>
</p>