### PR TITLE
Add link to Docs on the nav bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,6 +90,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
         },
         items: [
           {href: "https://flashbots.net", label: 'About', position: 'left'},
+          {href: "https://docs.flashbots.net/", label: 'Docs', position: 'left'},
           {href: "https://boost.flashbots.net/", label: 'MEV-Boost', position: 'left'},
           {href: "https://collective.flashbots.net/", label: 'Forum', position: 'left'},
           {href: "https://jobs.flashbots.net/", label: 'Join us', position: 'left'},


### PR DESCRIPTION
The Flashbots [homepage](https://flashbots.net) has a link to the [Documentation](https://docs.flashbots.net) that the Writings page was missing.

<p align="center">
<img src="https://user-images.githubusercontent.com/68292774/272312139-cb87d805-23c5-49ba-b83f-8541bd3040f4.png" alt="Screenshot of the Writings website showing a link to &quot;Docs&quot; at the top navigation bar" style="max-width: 100%;">
</p>

Closes #122