### PR TITLE
Stabilize text when changing window size

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -146,3 +146,8 @@ h1, h2, h3, h4, h5, h6 {
 .katex-display {
   overflow-x: scroll;
 }
+
+.container {
+  max-width: var(--ifm-container-width-xl);
+  width: 88vw;
+}

--- a/src/theme/.styles/mixins.scss
+++ b/src/theme/.styles/mixins.scss
@@ -1,14 +1,8 @@
 @import "./variables.scss";
 
 @mixin standardLayout {
-  max-width: $desktop-max-width;
-  width: 100%;
-  padding: 0 12px;
+  padding: 0;
   margin: 0 auto;
-  @media screen and (max-width: $desktop-max-width) {
-    width: 95vw;
-    max-width: 670px;
-  }
   background-color: var(--ifm-background-surface-color);
 }
 

--- a/src/theme/.styles/variables.scss
+++ b/src/theme/.styles/variables.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-$desktop-max-width: 80em;
 
 // random bg seed: 2192
 $transparent: rgba(255, 255, 255, 0);

--- a/src/theme/.styles/variables.scss
+++ b/src/theme/.styles/variables.scss
@@ -33,8 +33,6 @@ article {
 
 main {
   font-size: 1.15em !important;
-  padding-left: 4vw !important;
-  padding-right: 4vw !important;
 }
  
 .layoutDefaults_src-theme-Layout-styles-module {


### PR DESCRIPTION
# What
The column width for the text was jumping around when the user changed the browser width.

## Before
<p align="center">
<img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/2f68c46b-9379-4c36-bee3-ab14313bf026"/>
</p>

## After
<p align="center">
<img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/6b36b85a-a020-49b7-a8d4-f7e52401c1d8"/>
</p>

# How
There was an errand `@media` query setting the content width to `1140px` for a certain range of widths, which was conflicting with the "max width" of `780px` set for most other times. I removed that query and cleaned up the styling a bit to hopefully make everything more consistent.

The way it should work now is the text will remain the same width - `780px` - or 88% of the window size, whichever is bigger.

I also removed the padding on the `.main` element. It was set to `4vw`, meaning it would increase as the screen got wider. That caused the text to become _narrower_, even though the width itself wasn't changing. It was counterintuitive, so I decided to take it out.

---
Fixes #59 