### PR TITLE
Add new DuneDashboard component

### DIFF
--- a/src/components/DuneDashboard/DuneDashboard.js
+++ b/src/components/DuneDashboard/DuneDashboard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from  './styles.module.scss';
+
+export default function DuneDashboard({source, label, aspectRatio}) {
+  if (!source) return null
+
+  return (
+    <div className={styles.DuneDashboard} style={{"--aspect-ratio": aspectRatio}}>
+      <iframe src={source} className={styles.root} />
+      {label && <span>{label}</span>}
+    </div>
+  );
+}

--- a/src/components/DuneDashboard/styles.module.scss
+++ b/src/components/DuneDashboard/styles.module.scss
@@ -1,5 +1,5 @@
 :root {
-  --dashboard-border-color: var(--ifm-color-emphasis-300);
+  --dashboard-border-color: var(--ifm-color-emphasis-200);
   --dashboard-aspect-ratio: 16/13;
   --dashboard-border-radius: 0.5em;
 }

--- a/src/components/DuneDashboard/styles.module.scss
+++ b/src/components/DuneDashboard/styles.module.scss
@@ -1,0 +1,24 @@
+:root {
+  --dashboard-border-color: var(--ifm-color-emphasis-300);
+  --dashboard-aspect-ratio: 16/13;
+  --dashboard-border-radius: 0.5em;
+}
+
+.DuneDashboard{
+  display: flex;
+  flex-direction: column;
+  margin: 1.5em 0.4em;
+  background-color: var(--dashboard-border-color);
+  border: 1px solid var(--dashboard-border-color);
+  border-radius: var(--dashboard-border-radius);
+}
+
+.DuneDashboard > iframe {
+  aspect-ratio: var(--aspect-ratio, var(--dashboard-aspect-ratio));
+  border-radius: var(--dashboard-border-radius);
+}
+
+.DuneDashboard > span {
+  padding: 0.3em 0.7em;
+  font-size: small;
+}


### PR DESCRIPTION
Adding a new `DuneDashboard` component to let you embed a Dune dashboard to a blog post. Well, technically any embedding. Example:

```typescript
---
slug: my-blog-post
title: Introducing Dune Dashboards
authors: [flashbots]
---

import DuneDashboard from '@site/src/components/DuneDashboard/DuneDashboard'

If you'd like to embed a Dune dashboard to your post, just use this:

<DuneDashboard
  source="https://dune.com/embeds/3295088/5516700"
  label={<>You can add <code>HTML</code> labels!</>}
  aspectRatio="16/9" />
```

<p align="center">
<img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/1227667d-84ba-41d0-bda5-5f1ba7155a92" />
</p>

The component gives you control over:
- Source: The URL for the embedded element
- Label: Explanatory text added to the bottom of the embedding; Accepts HTML
- Aspect Ratio: Control the proportions of the element

# Instructions
Follow these steps to use the component in your post:

1. **Import the component**
  Add the following line to your blog post file after all the headers, as shown in the example above:
    ```typescript
    import DuneDashboard from '@site/src/components/DuneDashboard/DuneDashboard'
    ```
2. **Get the embedded URL from Dune**
  When viewing a dashboard you can click the "Share" button to see the option to "Embed Iframe". What we want is the `src` property from the provided `iframe`. Select and copy that URL to use with the component.
  <p align="center">
    <img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/1b6b7dbd-3d18-43e2-b164-03dbc8dd08e8"/>
  </p>

3. **Add a component to your blog post**
  Add a `DuneDashboard` component to your post using the URL you just copied as the `source` parameter:
    ```html
    <DuneDashboard source="https://dune.com/embeds/3295088/5516700"/>
    ```

4. **Add a label** - _optional_
    If you'd like to provide some context on what the dashboard is showing, you can add a `label` option to the component. The label can be plain text or HTML.

    HTML labels need to be surrounded by `{<>…</>}`

    The label is optional. If you omit it, the dashboard will still appear.
    ```html
    <DuneDashboard source="…" label="This is a plain text label"/>

    <DuneDashboard source="…" label={<>This label is <code>HTML</code></>}/>
    ```
  <p align="center">
    <img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/89bd49d9-bf1c-4ea3-9950-02a664d59687"/>
  </p>


5. **Customize the proportions** - _optional_
    All dashboards are the same width but you can control how tall it is using the `aspectRatio` option.

    By default all dashboards have a _squareish_ 16/13 aspect ratio and you can make it taller or shorter by altering that ratio. For instance, a 16/5 aspect ratio would make for a shorter dashboard, while a 16/18 ratio would mean a taller one.

    The custom aspect ratio is optional. If you omit it, the component will default to 16/13.
    ```html
    <DuneDashboard source="…" label="16/5 aspect ratio. Very short!" aspectRatio="16/5" />
    <DuneDashboard source="…" label="16/18 aspect ratio. Very tall!" aspectRatio="16/18" />
    ```
  <p align="center">
    <img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/a396e45b-b472-471f-933d-a551f21f5305"/>
  </p>


## Note on mobile view
The embedded dashboards will adapt to narrow phone screens to some extent, but Dune's support for it isn't great. The legend might overlap with the graph, or disappear entirely if there's not enough space.

It is strongly recommended that you test how the page looks on a phone screen and tweak the aspect ratio for any given dashboard accordingly. Sometimes it helps. Sometimes it doesn't. But it's important to keep that in mind.

If all else fails, a good label will get you very far:
<p align="center">
  <img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/8abc6333-308d-48d3-b1be-718752f5247c"/>
</p>

As a last tip, you can use your browser's Dev Tools to mess with the page's dimensions, to simulate a phone screen! In Chrome, on Mac, you can hit `⌘+⌥+i` to open Dev Tools, then `⌘+⇧+m` to turn on the mobile view simulator.