### PR TITLE
SEO: Add robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
Followed the instructions in the [Docusaurus docs](https://docusaurus.io/docs/next/seo#robots-file) to create a `robots.txt` file, to assist with our [SEO project](https://docs.google.com/presentation/d/1zRznWdOHz9ijfv-TOfkGSjqHv5gAFSETFtJ-e1d6wvI/edit#slide=id.g2644e6def94_0_37).

https://github.com/flashbots/flashbots-writings-website/blob/5c700fcef2159222857956023fee71666967686c/static/robots.txt#L1-L2

### To test
Visit the [preview URL](https://flashbots-writings-website-git-gkoscky-add-robots-txt-flashbots.vercel.app/) and add add `/robots.txt` to the end. You should see a plain file with the content listed above.

---
Task: [robots.txt file missing](https://docs.google.com/presentation/d/1zRznWdOHz9ijfv-TOfkGSjqHv5gAFSETFtJ-e1d6wvI/edit#slide=id.g2644e6def94_0_37)