### PR TITLE
SEO: Add MEV footer items

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -133,8 +133,25 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
             title: 'x',
             items: [
               {
+                label: 'What Is MEV',
+                href: 'https://docs.flashbots.net/new-to-mev',
+              },
+              {
+                label: 'MEV Protection',
+                href: 'https://docs.flashbots.net/flashbots-protect/overview',
+              },
+              {
                 label: 'The MEV Letter',
                 href: 'https://collective.flashbots.net/tag/the-mev-letter',
+              },
+            ],
+          },
+          {
+            title: 'x',
+            items: [
+              {
+                label: 'Ethereum Block Building',
+                href: 'https://docs.flashbots.net/flashbots-mev-boost/block-builders',
               },
               {
                 label: 'Transparency reports',


### PR DESCRIPTION
Changes to the site's footer to include the three links suggested by the SEO report:
- MEV Protection - `https://docs.flashbots.net/flashbots-protect/overview`
- What is MEV - `https://docs.flashbots.net/new-to-mev`
- Ethereum Block Building - https://docs.flashbots.net/flashbots-mev-boost/block-builders

I did a little bit of  rebalancing to keep the footer layout cohesive, but it should all still be there.

# Before
<p align="center">
  <img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/9e48edc7-91ca-4ef0-9d17-878767bfb2ca"/>
</p>

# After
<p align="center">
  <img src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/58e4dbfc-f142-4967-860a-d55f52e6d4d7"/>
</p>



---
Task: [internal links - navigation](https://docs.google.com/presentation/d/1zRznWdOHz9ijfv-TOfkGSjqHv5gAFSETFtJ-e1d6wvI/edit#slide=id.g134e1e21a95_0_0)

Following the SEO guide here: https://docs.google.com/spreadsheets/d/13Xa_TKfuKrWzrK0zCgJNnQPXFK95hiBxqnLWE7cvHN8/edit#gid=1368591461
