### PR TITLE
Fix default social media card

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,8 +80,8 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
         {name: 'twitter:card', content: 'summary_large_image'},
         {name: 'twitter:title', content: 'Writings'},
         {name: 'twitter:description', content: 'A collection of articles and papers from Flashbots.'},
-        {name: 'twitter:image', content: 'img/tw-card.jpg'}
       ],
+      image: 'img/tw-card.jpg',
       navbar: {
         title: "Flashbots",
         logo: {


### PR DESCRIPTION
Properly set the social media card image for the blog homepage

Test here: https://www.opengraph.xyz/url/https%3A%2F%2Fflashbots-writings-website-git-gkoscky-social-c0d727-flashbots.vercel.app%2F