### PR TITLE
Fix SEO information

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,8 +8,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 // With JSDoc @type annotations, IDEs can provide config autocompletion
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 (module.exports = {
-  title: "title Flashbots Writings",
-  tagline: "Research respository of Flashbots",
+  title: "Flashbots Writings",
   baseUrl: process.env.REACT_APP_BASE_URL,
   url: process.env.REACT_APP_TARGET_URL,
   onBrokenLinks: "throw",
@@ -48,8 +47,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
       ({
         docs: false,
         blog: {
-          blogTitle: "blog.blogTitle Writings",
-          blogDescription: "blog.blogDescription",
+          blogDescription: "A collection of articles and papers from Flashbots.",
           path: "./content",
           routeBasePath: "/",
           postsPerPage: "ALL",
@@ -77,11 +75,9 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       hideableSidebar: true,
-      metadata: [
-        {name: 'description', content:'Testing new titles'},
-        {name: 'twitter:card', content: 'summary_large_image'},
-        {name: 'twitter:title', content: 'Testing new titles'},
-        {name: 'twitter:description', content: 'Testing new titles'},
+      metadatas: [
+        {name: 'twitter:description', content: "A collection of articles and papers from Flashbots."},
+        {name: 'twitter:title', content: "Flashbots Writings"},
       ],
       image: 'img/tw-card.jpg',
       navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 // With JSDoc @type annotations, IDEs can provide config autocompletion
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 (module.exports = {
-  title: "Flashbots",
+  title: "title Flashbots Writings",
   tagline: "Research respository of Flashbots",
   baseUrl: process.env.REACT_APP_BASE_URL,
   url: process.env.REACT_APP_TARGET_URL,
@@ -48,7 +48,8 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
       ({
         docs: false,
         blog: {
-          blogTitle: "Writings",
+          blogTitle: "blog.blogTitle Writings",
+          blogDescription: "blog.blogDescription",
           path: "./content",
           routeBasePath: "/",
           postsPerPage: "ALL",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,9 +77,10 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
     ({
       hideableSidebar: true,
       metadata: [
+        {name: 'description', content:'Testing new titles'},
         {name: 'twitter:card', content: 'summary_large_image'},
-        {name: 'twitter:title', content: 'Writings'},
-        {name: 'twitter:description', content: 'A collection of articles and papers from Flashbots.'},
+        {name: 'twitter:title', content: 'Testing new titles'},
+        {name: 'twitter:description', content: 'Testing new titles'},
       ],
       image: 'img/tw-card.jpg',
       navbar: {

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -67,13 +67,8 @@ const paginate = function (array: Array<any>[], index: number, size: number, tag
 
 
 function BlogListPage(props: Props): JSX.Element {
-  const { metadata, items, location } = props
-  const {
-    siteConfig: { title: siteTitle }
-  } = useDocusaurusContext()
-  const { blogDescription, blogTitle, permalink } = metadata
-  const isBlogOnlyMode = permalink === "/"
-  const title = isBlogOnlyMode ? siteTitle : blogTitle
+  const { metadata, items } = props
+  const { blogDescription } = metadata
   const tags = extractTags(props)
   const tagsListRef = React.useRef(null)
   const [page, setPage] = useState(0)
@@ -98,7 +93,6 @@ function BlogListPage(props: Props): JSX.Element {
   const [searchFilter, setSearchFilter] = useState("")
   return (
       <BlogLayout
-        title={title}
         description={blogDescription}
         wrapperClassName={clsx(ThemeClassNames.wrapper.blogPages, styles.blogPageRoot)}
         pageClassName={ThemeClassNames.page.blogListPage}


### PR DESCRIPTION
Two fixes here:
1. **Correct SEO information metadata**
These values were not properly set due to a number of misconfigurations and conflicts in `docusaurus.config.js`. So I cleaned it up and set the correct values for proper meta-tag generation. New values:
   - **Title**: Flashbots Writings
   - **Description**: A collection of articles and papers from Flashbots.


2. **Avoid repeated title in homepage**
  The blog's homepage will duplicate the title if you give it as a parametet. So if you pass it the title "Flashbots Writings", the final title will be "Flashbots Writings | Flashbots Writings". To avoid that I removed the parameter from the frontpage template

To test everything, check the values and generated cards in Opengraph.xyz:
https://www.opengraph.xyz/url/https%3A%2F%2Fflashbots-writings-website-git-gkoscky-social-537084-flashbots.vercel.app