### PR TITLE
Change blog post date format

### DIFF
--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -85,7 +85,7 @@ function BlogPostItem(props: Props): JSX.Element {
         <div className={clsx(styles.blogPostData, 'margin-hori--md')}>
           <span>
             <time dateTime={date} itemProp="datePublished">
-              { dayjs(date).format("DD.MM.YY") }
+              { dayjs(date).format("YYYY-MM-DD") }
             </time>
 
             {typeof readingTime !== 'undefined' && (


### PR DESCRIPTION
Use `YYYY-MM-DD` instead of `DD.MM.YY`:
<img width="672" alt="image" src="https://github.com/flashbots/flashbots-writings-website/assets/68292774/f76d10f2-de75-4713-a203-905cd842d4c8">

---
[Request](https://flashbots.slack.com/archives/C03DVJ4L8NP/p1715590494783899)