### PR TITLE
post: migrating to buildernet

### DIFF
--- a/content/2024-12-09-migrating-to-buildernet.mdx
+++ b/content/2024-12-09-migrating-to-buildernet.mdx
@@ -1,0 +1,16 @@
+---
+slug: migrating-to-buildernet
+title: Migrating to BuilderNet
+authors: [flashbots]
+tags: [building, decentralization]
+hide_table_of_contents: false
+description: Block building must be made decentralized, uncensorable, and neutral. To accelerate decentralization in block building, Flashbots has deprecated our centralized block builders and migrated our orderflow and refunds to BuilderNet.
+---
+
+Block building must be made decentralized, uncensorable, and neutral. To accelerate decentralization in block building, Flashbots has deprecated our centralized block builders and migrated our orderflow and refunds to [BuilderNet](https://buildernet.org/).
+
+BuilderNet will make Ethereum more resilient by introducing a neutral way for many parties to share orderflow and collaborate in building blocks. It will also create better user experiences by providing a fair and equal platform to trade, and using verifiable ordering rules and improved privacy techniques to keep users safe.
+
+As of December 5 2024, Flashbots no longer operates centralized block builders on Ethereum. A few instances will remain as backups to ensure continuity of service in extraordinary situations during the BuilderNet alpha period.
+
+We invite the community to join us in developing BuilderNet, and to accelerate decentralization and neutrality in block building.


### PR DESCRIPTION
No more centralized block builders.