### PR TITLE
Update year

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -174,7 +174,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
             ],
           },
         ],
-        copyright: `© ${new Date().getFullYear()} Flashbots, Ltd`,
+        copyright: `© 2025 Flashbots, Ltd`,
       },
       // algolia: {
       //   apiKey: '',


### PR DESCRIPTION
This part of the code was not working correctly, displaying the year 2024 instead of 2025. 
@freddmannen approved this change via slack.